### PR TITLE
Calculate P-Value via ToyMC

### DIFF
--- a/GOFevaluation/evaluators_nd.py
+++ b/GOFevaluation/evaluators_nd.py
@@ -5,19 +5,7 @@ from scipy.interpolate import interp1d
 from GOFevaluation import test_statistics
 
 
-class nd_test_statistics(test_statistics):
-    """
-        Override binning to work in arbitrary dimensions
-    """
-    def bin_data(self, bin_edges):
-        # function to bin nD data:
-        if len(self.data.shape)==1:
-            self.binned_data, _ = np.histogram(self.data, bins=bin_edges)
-        else:
-            self.binned_data, _ = np.histogramdd(self.data, bins=bin_edges)
-
-
-class binned_poisson_chi2_gof(nd_test_statistics):
+class binned_poisson_chi2_gof(test_statistics):
     """
         computes the binned poisson modified Chi2 from Baker+Cousins
         In the limit of large bin counts (10+) this is Chi2 distributed.
@@ -41,7 +29,7 @@ class binned_poisson_chi2_gof(nd_test_statistics):
         In this case the bin-edges don't matter, so we bypass the usual init
         """
         self = cls(None, None, None, None)
-        nd_test_statistics.__init__(self=self,
+        test_statistics.__init__(self=self,
                                     data=data,
                                     pdf=expectations / np.sum(expectations),
                                     nevents_expected=np.sum(expectations))
@@ -56,7 +44,7 @@ class binned_poisson_chi2_gof(nd_test_statistics):
             # bypass init, using binned data
             return
         # initialise with the common call signature
-        nd_test_statistics.__init__(self=self,
+        test_statistics.__init__(self=self,
                                     data=data,
                                     pdf=pdf,
                                     nevents_expected=nevents_expected)

--- a/GOFevaluation/test_statistics.py
+++ b/GOFevaluation/test_statistics.py
@@ -13,7 +13,11 @@ class test_statistics(object):
         raise NotImplementedError("Your goodnes of fit computation goes here!")
 
     def bin_data(self, bin_edges):
-        self.binned_data, _ = np.histogram(self.data, bins=bin_edges)
+        # function to bin nD data:
+        if len(self.data.shape)==1:
+            self.binned_data, _ = np.histogram(self.data, bins=bin_edges)
+        else:
+            self.binned_data, _ = np.histogramdd(self.data, bins=bin_edges)
 
     def get_result_as_dict(self):
         assert self._name is not None, str(self.__class__.__name__) + ": You need to define self._name for your goodnes of fit measure!"


### PR DESCRIPTION
I'm in the process of incorporating this package into bbf, and realized my use case might be somewhat common. I have a histogrammed model (ER template) and histogrammed data (Rn220 data), and want the p-value of the fit. With this PR you can do (if e.g. these are both multihists):

    from GOFevaluation import binned_poisson_chi2_gof
    gof_object = binned_poisson_chi2_gof.from_binned(datahist.histogram, mchist.histogram)
    gof_object.get_pvalue(n_mc=1000)

If you want to plot the distribution of GoF's, you can do:

    gofs = gof_object.sample_gofs()
    hist, bin_edges = np.histogram(gofs, bins=1000)
    cumulative_density = 1.0 - np.cumsum(hist)/np.sum(hist)
    plt.plot(np.mean(np.vstack([bin_edges[0:-1], bin_edges[1:]]), axis=0), cumulative_density)
    plt.axvline(gof_object.calculate_gof())
    plt.ylabel('P(less than GoF)')
    plt.xlabel('GoF')
    plt.show()

to get:
<img width="626" alt="pva" src="https://user-images.githubusercontent.com/16269427/117360469-d5c15500-ae86-11eb-837f-8c48a3340189.png">

