### PR TITLE
Improvements for EQPB

### DIFF
--- a/GOFevaluation/evaluators_nd.py
+++ b/GOFevaluation/evaluators_nd.py
@@ -143,7 +143,10 @@ class BinnedChi2GOF(EvaluatorBaseBinned):
     @staticmethod
     def calculate_gof(binned_data, binned_reference):
         """Get Chi2 GoF from binned data & expectations
-        # """
+        """
+        assert (binned_reference > 0).all(), ("binned_reference contains "
+                                              + "entries of zero that would "
+                                              + "cause an infinite GOF value!")
         if binned_reference.min() / binned_reference.max() < 1 / 100:
             warnings.warn(
                 'Binned reference contains bin counts ranging over '

--- a/GOFevaluation/utils.py
+++ b/GOFevaluation/utils.py
@@ -167,6 +167,8 @@ def plot_irregular_binning(ax, bin_edges, order=None, c='k', **kwargs):
     :param kwargs: kwargs are passed to the plot functions
     :raises ValueError: when an unknown order is passed.
     """
+    if order is None:
+        order = [0, 1]
     if bin_edges[0].shape == ():
         for line in bin_edges:
             ax.axvline(line, c=c, zorder=4, **kwargs)
@@ -200,7 +202,7 @@ def plot_irregular_binning(ax, bin_edges, order=None, c='k', **kwargs):
             i += 1
 
 
-def plot_equiprobable_histogram(data_sample, bin_edges, order,
+def plot_equiprobable_histogram(data_sample, bin_edges, order=None,
                                 ax=None, cmap_midpoint=None, **kwargs):
     """Plot 2d histogram of data sample binned according to the passed
     irregular binning.
@@ -221,6 +223,8 @@ def plot_equiprobable_histogram(data_sample, bin_edges, order,
     :type cmap_midpoint: float, optional
     :raises ValueError: when an unknown order is passed.
     """
+    if order is None:
+        order = [0, 1]
     if ax is None:
         _, ax = mpl.pyplot.subplots(1, figsize=(4, 4))
     ylim = ax.get_ylim()
@@ -229,7 +233,8 @@ def plot_equiprobable_histogram(data_sample, bin_edges, order,
     ns = apply_irregular_binning(data_sample, bin_edges, order=order)
 
     # get colormap and norm for colorbar
-    cmap = mpl.cm.get_cmap('RdBu').reversed()
+    cmap_str = kwargs.get('cmap', 'RdBu_r')
+    cmap = mpl.cm.get_cmap(cmap_str)
     if cmap_midpoint is None:
         norm = mpl.colors.Normalize(vmin=ns.min(), vmax=ns.max())
     else:

--- a/GOFevaluation/utils.py
+++ b/GOFevaluation/utils.py
@@ -250,6 +250,10 @@ def plot_equiprobable_histogram(data_sample, bin_edges, order=None,
     # get colormap and norm for colorbar
     cmap_str = kwargs.get('cmap', 'RdBu_r')
     cmap = mpl.cm.get_cmap(cmap_str)
+    try:
+        kwargs.pop('cmap')
+    except KeyError:
+        pass
     if nevents_expected is None:
         norm = mpl.colors.Normalize(vmin=ns.min(), vmax=ns.max())
     else:

--- a/GOFevaluation/utils.py
+++ b/GOFevaluation/utils.py
@@ -33,7 +33,7 @@ def equiprobable_histogram(data_sample, reference_sample, n_partitions,
         Reference: F. James, 2008: "Statistical Methods in Experimental
                     Physics", Ch. 11.2.3
     """
-    bin_edges = get_equiprobable_binning(
+    bin_edges = _get_equiprobable_binning(
         reference_sample=reference_sample, n_partitions=n_partitions,
         order=order)
     n = apply_irregular_binning(data_sample=data_sample,
@@ -47,7 +47,7 @@ def equiprobable_histogram(data_sample, reference_sample, n_partitions,
     return n, bin_edges
 
 
-def get_equiprobable_binning(reference_sample, n_partitions, order=None):
+def _get_equiprobable_binning(reference_sample, n_partitions, order=None):
     """Define an equiprobable binning for the reference sample. The binning
     is defined such that the number of counts in each bin are (almost) equal.
     Bins are defined based on the ECDF of the reference sample.
@@ -203,8 +203,9 @@ def plot_irregular_binning(ax, bin_edges, order=None, c='k', **kwargs):
 
 
 def plot_equiprobable_histogram(data_sample, bin_edges, order=None,
-                                ax=None, nevents_expected=None, **kwargs):
-    """Plot 2d histogram of data sample binned according to the passed
+                                ax=None, nevents_expected=None, plot_xlim=None,
+                                plot_ylim=None, **kwargs):
+    """Plot 1d/2d histogram of data sample binned according to the passed
     irregular binning.
 
     :param data_sample: Sample of unbinned data.
@@ -223,14 +224,26 @@ def plot_equiprobable_histogram(data_sample, bin_edges, order=None,
         z-axis in units of sigma-deviation from expectation. If None is passed,
         cmap scale ranges from min to max. Defaults to None.
     :type nevents_expected: float, optional
+    :param plot_xlim: xlim to use for the plot. If None is passed, take min and
+        max values of the data sample. Defaults to None.
+    :type plot_xlim: tuple, optional
+    :param plot_ylim: ylim to use for the plot. If None is passed, take min and
+        max values of the data sample. Defaults to None.
+    :type plot_ylim: tuple, optional
     :raises ValueError: when an unknown order is passed.
     """
     if order is None:
         order = [0, 1]
     if ax is None:
         _, ax = mpl.pyplot.subplots(1, figsize=(4, 4))
-    ylim = ax.get_ylim()
-    xlim = ax.get_xlim()
+    if (plot_xlim is None) or (plot_ylim is None):
+        xlim, ylim = get_plot_limits(data_sample)
+    if plot_xlim is not None:
+        xlim = plot_xlim
+    if plot_ylim is not None:
+        ylim = plot_ylim
+    ax.set_xlim(xlim)
+    ax.set_ylim(ylim)
 
     ns = apply_irregular_binning(data_sample, bin_edges, order=order)
 
@@ -278,6 +291,7 @@ def plot_equiprobable_histogram(data_sample, bin_edges, order=None,
 
         # plot rectangle for each bin
         i = 0
+        edgecolor = kwargs.get('edgecolor', 'k')
         for low_f, high_f in zip(be_first[:-1], be_first[1:]):
             j = 0
             for low_s, high_s in zip(be_second[i][:-1], be_second[i][1:]):
@@ -286,12 +300,14 @@ def plot_equiprobable_histogram(data_sample, bin_edges, order=None,
                                     high_f - low_f,
                                     high_s - low_s,
                                     facecolor=cmap(norm(ns[i][j])),
+                                    edgecolor=edgecolor,
                                     **kwargs)
                 elif order == [1, 0]:
                     rec = Rectangle((low_s, low_f),
                                     high_s - low_s,
                                     high_f - low_f,
                                     facecolor=cmap(norm(ns[i][j])),
+                                    edgecolor=edgecolor,
                                     **kwargs)
                 ax.add_patch(rec)
                 j += 1
@@ -300,7 +316,7 @@ def plot_equiprobable_histogram(data_sample, bin_edges, order=None,
     if nevents_expected is None:
         label = 'Counts per Bin'
     else:
-        label = r'$\sigma$-deviation from expected'
+        label = r'$\sigma$-deviation from expectation'
     fig.colorbar(mpl.cm.ScalarMappable(norm=norm, cmap=cmap), ax=ax,
                  label=label)
 
@@ -312,3 +328,19 @@ def get_n_bins(eqpb_bin_edges):
         n_bins = (eqpb_bin_edges[1].shape[0]
                   * (eqpb_bin_edges[1].shape[1] - 1))
     return n_bins
+
+
+def get_plot_limits(data_sample):
+    if len(data_sample.shape) == 1:
+        xlim = (min(data_sample), max(data_sample))
+        ylim = None
+    else:
+        xlim = (min(data_sample.T[0]), max(data_sample.T[0]))
+        ylim = (min(data_sample.T[1]), max(data_sample.T[1]))
+
+    return xlim, ylim
+
+
+def check_sample_sanity(sample):
+    assert ~np.isnan(sample).any(), 'Sample contains NaN entries!'
+    assert ~np.isinf(sample).any(), 'Sample contains inf values!'


### PR DESCRIPTION
This PR improves the usability of the equiprobable binning functions. 

Based on the very helpful feedback I got from @hoetzsch the following things were changed:

- Plot eqpb histogram when initialising the GOF object by passing `plot=True` (see example below)
- Determine cmap midpoint automatically if `nevents_expected` is passed
- Infer plot limits from data sample if not explicitly passed as arguments. (Before limits had to be set before plotting the eqpb)
- Show sigma-deviation from expectation instead of number of counts if `nevents_expected` is passed
- Some assertions for sane data were added


**Code Example**
```python
import GOFevaluation as ge
import scipy.stats as sps
import matplotlib.pyplot as plt

# Generate toy data sample and reference sample
reference_sample = sps.norm().rvs([125*100, 2])
reference_sample.T[1] += reference_sample.T[0]
data_sample = sps.norm().rvs([125, 2])
data_sample.T[1] += data_sample.T[0]

# define eqpb parameters
order = [0, 1]
n_partitions = [5, 5]

gof_object = ge.BinnedPoissonChi2GOF.bin_equiprobable(data_sample=data_sample,
                                                      reference_sample=reference_sample,
                                                      nevents_expected=125,
                                                      n_partitions=n_partitions,
                                                      order=order,
                                                      plot=True,
                                                     )
ax = plt.gca()
ax.set_xlabel('$x_1$')
ax.set_ylabel('$x_2$')
```
![pr26_example](https://user-images.githubusercontent.com/53221264/137766039-7d8d8694-9364-4d03-b9ae-3ec6e42f0bff.png)
