### PR TITLE
Downgrading testing

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "windows-latest"]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        os: ["ubuntu-latest"]
+        python-version: [3.8]
 
     steps:
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
To adres https://xenonnt.slack.com/archives/C016UJZ090B/p1635411304020900, we might be careful doing too much platform dependent testing on private repos.

The main culprit for the issue is https://github.com/XENONnT/private_nt_aux_files/ by a large margin, but let's try and prevent running into a situation as in attached link.