### PR TITLE
a few patches

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: '3.7'
       - name: Checkout repo
         uses: actions/checkout@v2
       - name: Install dependencies

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - name: Set up Python ${{ matrix.python-version }}

--- a/GOFevaluation/evaluator_base.py
+++ b/GOFevaluation/evaluator_base.py
@@ -276,12 +276,12 @@ class EvaluatorBaseSample(EvaluatorBase):
             warnings.warn(f'p-value is 0.0. (Observed GoF: '
                           f'{self.gof:.2e}, maximum of simulated GoFs: '
                           f'{max(fake_gofs):.2e}). For a more '
-                          f'precise result, increase n_mc!', stacklevel=2)
+                          f'precise result, increase n_perm!', stacklevel=2)
         elif pvalue == 1:
             warnings.warn(f'p-value is 1.0. (Observed GoF '
                           f'{self.gof:.2e}, minimum of simulated GoFs: '
                           f'{min(fake_gofs):.2e}). For a more '
-                          f'precise result, increase n_mc!', stacklevel=2)
+                          f'precise result, increase n_perm!', stacklevel=2)
         self.pvalue = pvalue
 
         return pvalue, fake_gofs

--- a/GOFevaluation/evaluator_base.py
+++ b/GOFevaluation/evaluator_base.py
@@ -175,11 +175,15 @@ class EvaluatorBaseBinned(EvaluatorBase):
         return pvalue, fake_gofs
 
     def get_pvalue(self, n_mc=1000):
-        """p-value is calculated
+        """The approximate p-value is calculated.
 
         Computes the p-value by means of generating toyMCs and calculating
         their GoF. The p-value can then be obtained from the distribution of
         these fake-gofs.
+
+        Note that this is only an approximate method, since the model is not
+        refitted to the toy data. Especially with low statistics and many fit
+        parameters, this can introduce a bias towards larger p-values.
 
         :param n_mc: Number of fake-gofs calculated, defaults to 1000
         :type n_mc: int, optional
@@ -190,12 +194,16 @@ class EvaluatorBaseBinned(EvaluatorBase):
         return pvalue
 
     def get_pvalue_return_fake_gofs(self, n_mc=1000):
-        """p-value is calculated
+        """The approximate p-value is calculated.
 
         Computes the p-value by means of generating toyMCs and calculating
         their GoF. The p-value can then be obtained from the distribution of
         these fake-gofs. The array of fake-gofs is returned together with
         the p-value.
+
+        Note that this is only an approximate method, since the model is not
+        refitted to the toy data. Especially with low statistics and many fit
+        parameters, this can introduce a bias towards larger p-values.
 
         :param n_mc: Number of fake-gofs calculated, defaults to 1000
         :type n_mc: int, optional
@@ -287,12 +295,16 @@ class EvaluatorBaseSample(EvaluatorBase):
         return pvalue, fake_gofs
 
     def get_pvalue(self, n_perm=1000, d_min=None):
-        """p-value is calculated
+        """The approximate p-value is calculated.
 
         Computes the p-value by means of re-sampling data sample
         and reference sample. For each re-sampling, the gof is calculated.
         The p-value can then be obtained from the distribution of these
         fake-gofs.
+
+        Note that this is only an approximate method, since the model is not
+        refitted to the re-sampled data. Especially with low statistics and
+        many fit parameters, this can introduce a bias towards larger p-values.
 
         :param n_perm: Number of fake-gofs calculated, defaults to 1000
         :type n_perm: int, optional
@@ -303,13 +315,17 @@ class EvaluatorBaseSample(EvaluatorBase):
         return pvalue
 
     def get_pvalue_return_fake_gofs(self, n_perm=1000, d_min=None):
-        """p-value is calculated
+        """The approximate p-value is calculated.
 
         Computes the p-value by means of re-sampling data sample
         and reference sample. For each re-sampling, the gof is calculated.
         The p-value can then be obtained from the distribution of these
         fake-gofs. The array of fake-gofs is returned together with
         the p-value.
+
+        Note that this is only an approximate method, since the model is not
+        refitted to the re-sampled. Especially with low statistics and many fit
+        parameters, this can introduce a bias towards larger p-values.
 
         :param n_perm: Number of fake-gofs calculated, defaults to 1000
         :type n_perm: int, optional

--- a/GOFevaluation/evaluators_nd.py
+++ b/GOFevaluation/evaluators_nd.py
@@ -305,12 +305,16 @@ class PointToPointGOF(EvaluatorBaseSample):
         return gof
 
     def get_pvalue(self, n_perm=1000, d_min=None):
-        """p-value is calculated
+        """The approximate p-value is calculated.
 
         Computes the p-value by means of re-sampling data sample
         and reference sample. For each re-sampling, the gof is calculated.
         The p-value can then be obtained from the distribution of these
         fake-gofs.
+
+        Note that this is only an approximate method, since the model is not
+        refitted to the re-sampled data. Especially with low statistics and
+        many fit parameters, this can introduce a bias towards larger p-values.
 
         :param n_perm: Number of fake-gofs calculated, defaults to 1000
         :type n_perm: int, optional

--- a/GOFevaluation/evaluators_nd.py
+++ b/GOFevaluation/evaluators_nd.py
@@ -92,7 +92,7 @@ class BinnedPoissonChi2GOF(EvaluatorBaseBinned):
 
 
 class BinnedChi2GOF(EvaluatorBaseBinned):
-    """Compoutes the binned chi2 GoF based on Pearson's chi2.
+    """Computes the binned chi2 GoF based on Pearson's chi2.
 
         - **unbinned data, bin with regular binning**
             :param data_sample: sample of unbinned data

--- a/GOFevaluation/evaluators_nd.py
+++ b/GOFevaluation/evaluators_nd.py
@@ -29,8 +29,8 @@ class BinnedPoissonChi2GOF(EvaluatorBaseBinned):
             :param data_sample: sample of unbinned data
             :type data_sample: array_like, n-Dimensional
             :param reference_sample: sample of unbinned reference
-                (should have >50 samples than the data sample so that
-                statistical fluctuations are negligible.)
+                (should have at least 50 times larger than the data sample
+                to ensure that statistical fluctuations are negligible.)
             :type reference_sample: array_like, n-Dimensional
             :param nevents_expected: total number of expected events
             :type nevents_expected: float
@@ -109,8 +109,8 @@ class BinnedChi2GOF(EvaluatorBaseBinned):
             :param data_sample: sample of unbinned data
             :type data_sample: array_like, n-Dimensional
             :param reference_sample: sample of unbinned reference
-                (should have >50 samples than the data sample so that
-                statistical fluctuations are negligible.)
+                (should have at least 50 times larger than the data sample
+                to ensure that statistical fluctuations are negligible.)
             :type reference_sample: array_like, n-Dimensional
             :param nevents_expected: total number of expected events
             :type nevents_expected: float

--- a/GOFevaluation/gof_test.py
+++ b/GOFevaluation/gof_test.py
@@ -123,7 +123,7 @@ class GOFTest(object):
         return self.gofs
 
     def get_pvalues(self, **kwargs):
-        """Calculate p-values for individual GoF measures.
+        """Calculate the approximate p-values for individual GoF measures.
 
         :param kwargs: All parameters from a get_pvalue method are viable kwargs.
             gof_list: A list of gof_measures for which p-value should be

--- a/GOFevaluation/gof_test.py
+++ b/GOFevaluation/gof_test.py
@@ -2,11 +2,11 @@ from collections import OrderedDict
 from inspect import signature
 import warnings
 
-from GOFevaluation.evaluators_1d import ADTestTwoSampleGOF
-from GOFevaluation.evaluators_1d import KSTestTwoSampleGOF
-from GOFevaluation.evaluators_nd import BinnedPoissonChi2GOF
-from GOFevaluation.evaluators_nd import BinnedChi2GOF
-from GOFevaluation.evaluators_nd import PointToPointGOF
+from GOFevaluation.evaluators_1d import ADTestTwoSampleGOF  # noqa: F401
+from GOFevaluation.evaluators_1d import KSTestTwoSampleGOF  # noqa: F401
+from GOFevaluation.evaluators_nd import BinnedPoissonChi2GOF  # noqa: F401
+from GOFevaluation.evaluators_nd import BinnedChi2GOF  # noqa: F401
+from GOFevaluation.evaluators_nd import PointToPointGOF  # noqa: F401
 
 
 class GOFTest(object):

--- a/GOFevaluation/utils.py
+++ b/GOFevaluation/utils.py
@@ -40,7 +40,7 @@ def equiprobable_histogram(data_sample, reference_sample, n_partitions,
     """
     check_dimensionality_for_eqpb(data_sample, reference_sample,
                                   n_partitions, order)
-    bin_edges = _get_equiprobable_binning(
+    bin_edges = get_equiprobable_binning(
         reference_sample=reference_sample, n_partitions=n_partitions,
         order=order, reference_sample_weights=reference_sample_weights)
     n = apply_irregular_binning(data_sample=data_sample,
@@ -261,7 +261,6 @@ def get_equiprobable_binning(reference_sample, n_partitions,
             bin_edges_second.append(bin_edges)
         bin_edges_second = np.array(bin_edges_second)
         bin_edges = [bin_edges_first, bin_edges_second]
-
     return bin_edges
 
 

--- a/GOFevaluation/utils.py
+++ b/GOFevaluation/utils.py
@@ -2,6 +2,7 @@ from matplotlib.patches import Rectangle
 from sklearn.preprocessing import KBinsDiscretizer
 import numpy as np
 import matplotlib as mpl
+import warnings
 
 
 def equiprobable_histogram(data_sample, reference_sample, n_partitions,
@@ -162,6 +163,7 @@ def _get_equiprobable_binning(reference_sample, n_partitions, order=None):
         Reference: F. James, 2008: "Statistical Methods in Experimental
                     Physics", Ch. 11.2.3
     """
+    check_for_ties(reference_sample)
     if len(reference_sample.shape) == 1:
         dim = 1
     elif len(reference_sample.shape) == 2:
@@ -356,7 +358,7 @@ def plot_equiprobable_histogram(data_sample, bin_edges, order=None,
         cmap_str = kwargs.pop('cmap', 'RdBu_r')
         cmap = mpl.cm.get_cmap(cmap_str)
         if nevents_expected is None:
-            raise ValueError('nevents_expected cannot ' +
+            raise ValueError('nevents_expected cannot '
                              'be None while plot_mode=\'sigma_deviation\'')
 
         n_bins = get_n_bins(bin_edges)
@@ -449,6 +451,13 @@ def get_plot_limits(data_sample):
 def check_sample_sanity(sample):
     assert ~np.isnan(sample).any(), 'Sample contains NaN entries!'
     assert ~np.isinf(sample).any(), 'Sample contains inf values!'
+
+
+def check_for_ties(sample):
+    any_ties = len(np.unique(sample, axis=0)) != len(sample)
+    if any_ties:
+        warnings.warn("reference_sample contains ties, this might "
+                      "cause problems!", stacklevel=2)
 
 
 def check_dimensionality_for_eqpb(data_sample, reference_sample,

--- a/GOFevaluation/utils.py
+++ b/GOFevaluation/utils.py
@@ -4,6 +4,7 @@ from sklearn.preprocessing import KBinsDiscretizer
 import numpy as np
 import matplotlib as mpl
 import matplotlib.pyplot as plt
+from copy import deepcopy
 
 
 def equiprobable_histogram(data_sample, reference_sample, n_partitions,
@@ -75,12 +76,12 @@ def _get_finite_bin_edges(bin_edges, data_sample, order):
     xlim, ylim = get_plot_limits(data_sample)
     be = []
     if len(data_sample.shape) == 1:
-        bin_edges[0] = xlim[0]
-        bin_edges[-1] = xlim[1]
-        be = [bin_edges.copy(), None]
+        be = [deepcopy(bin_edges), None]
+        be[0][0] = xlim[0]
+        be[0][-1] = xlim[1]
     else:
-        be_first = bin_edges[0].copy()
-        be_second = bin_edges[1].copy()
+        be_first = deepcopy(bin_edges[0])
+        be_second = deepcopy(bin_edges[1])
 
         if order == [0, 1]:
             be_first[be_first == -np.inf] = xlim[0]
@@ -399,13 +400,13 @@ def plot_equiprobable_histogram(data_sample, bin_edges, order=None,
     norm = mpl.colors.Normalize(vmin=kwargs.pop('vmin', vmin),
                                 vmax=kwargs.pop('vmax', vmax),
                                 clip=False)
-    
+
     edgecolor = kwargs.pop('edgecolor', 'k')
     if len(data_sample.shape) == 1:
         i = 0
-        bin_edges[0] = xlim[0]
-        bin_edges[-1] = xlim[1]
-        for low, high in zip(bin_edges[:-1], bin_edges[1:]):
+        be_first[0] = xlim[0]
+        be_first[-1] = xlim[1]
+        for low, high in zip(be_first[:-1], be_first[1:]):
             ax.axvspan(low,
                        high,
                        facecolor=cmap(norm(ns[i])),

--- a/GOFevaluation/utils.py
+++ b/GOFevaluation/utils.py
@@ -340,7 +340,7 @@ def plot_equiprobable_histogram(data_sample, bin_edges, order=None,
     be_first = be[0]
     be_second = be[1]
 
-    if(plot_mode == 'sigma_deviation'):
+    if (plot_mode == 'sigma_deviation'):
         cmap_str = kwargs.pop('cmap', 'RdBu_r')
         cmap = mpl.cm.get_cmap(cmap_str)
         if nevents_expected is None:
@@ -356,14 +356,14 @@ def plot_equiprobable_histogram(data_sample, bin_edges, order=None,
                                     vmax=sigma_deviation)
         label = (r'$\sigma$-deviation from $\mu_\mathrm{{bin}}$ ='
                  + f'{midpoint:.1f} counts')
-    elif(plot_mode == 'count_density'):
+    elif (plot_mode == 'count_density'):
         label = r'Counts per area in each bin'
         ns = _get_count_density(ns, be_first, be_second, data_sample)
         cmap_str = kwargs.pop('cmap', 'viridis')
         cmap = mpl.cm.get_cmap(cmap_str)
         norm = mpl.colors.Normalize(vmin=np.min(ns),
                                     vmax=np.max(ns))
-    elif(plot_mode == 'num_counts'):
+    elif (plot_mode == 'num_counts'):
         label = r'Number of counts in eace bin'
         cmap_str = kwargs.pop('cmap', 'viridis')
         cmap = mpl.cm.get_cmap(cmap_str)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Evaluate the Goodness-of-Fit (GoF) for binned or unbinned data.
 [![Coverage Status](https://coveralls.io/repos/github/XENONnT/GOFevaluation/badge.svg?branch=master)](https://coveralls.io/github/XENONnT/GOFevaluation?branch=master) 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5626909.svg)](https://doi.org/10.5281/zenodo.5626909)
 
-This GoF suite comprises the possibility to calculate different 1D / nD, binned / two-sample (unbinned) GoF measures and the corresponding p-value. A list of implemented measures is given below. 
+This GoF suite comprises the possibility to calculate different 1D / nD, binned / two-sample (unbinned) GoF measures and the corresponding approximate p-value. A list of implemented measures is given below. 
 
  
 ## Implemented GoF measures

--- a/setup.py
+++ b/setup.py
@@ -26,11 +26,10 @@ setuptools.setup(
         'pytest',
         'flake8',
     ],
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     url="https://github.com/XENONnT/GOFevaluation",
     packages=setuptools.find_packages(),
     classifiers=[
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -109,9 +109,9 @@ class TestEqpb(unittest.TestCase):
             self.assertEqual(np.shape(n), np.shape(count_density))
             for i in range(0, len(edges[0]) - 1):
                 for j in range(0, len(edges[1][i]) - 1):
-                    if(order == [0, 1]):
+                    if (order == [0, 1]):
                         self.assertAlmostEqual(1, count_density[i][j],
                                                places=12)
-                    elif(order == [1, 0]):
+                    elif (order == [1, 0]):
                         self.assertAlmostEqual(1, count_density[i][j],
                                                places=12)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -170,7 +170,7 @@ class TestEqpb(unittest.TestCase):
         reference_sample = np.linspace(0, 1, 20)
         n_partitions = 4
         order = None
-        
+
         error_raised = False
         try:
             check_dimensionality_for_eqpb(data_sample=data_sample,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,13 @@
 # import scipy.stats as sps
 import numpy as np
 import unittest
+import warnings
 
 from GOFevaluation.utils import equiprobable_histogram
 from GOFevaluation.utils import _get_finite_bin_edges
 from GOFevaluation.utils import _get_count_density
+from GOFevaluation.utils import check_for_ties
+from GOFevaluation.utils import check_dimensionality_for_eqpb
 
 
 class TestEqpb(unittest.TestCase):
@@ -115,3 +118,108 @@ class TestEqpb(unittest.TestCase):
                     elif order == [1, 0]:
                         self.assertAlmostEqual(1, count_density[i][j],
                                                places=12)
+
+    def test_check_for_ties_1d(self):
+        a = np.linspace(0, 1, 10)
+
+        sample = np.concatenate((a, a))
+        warning_raised = False
+        with warnings.catch_warnings():
+            warnings.filterwarnings('error')
+            try:
+                check_for_ties(sample)
+            except Warning:
+                warning_raised = True
+        self.assertTrue(warning_raised)
+
+        sample = a
+        warning_raised = False
+        with warnings.catch_warnings():
+            warnings.filterwarnings('error')
+            try:
+                check_for_ties(sample)
+            except Warning:
+                warning_raised = True
+        self.assertFalse(warning_raised)
+
+    def test_check_for_ties_2d(self):
+        a = np.vstack((np.linspace(0, 1, 10), np.linspace(0, 1, 10))).T
+
+        sample = np.concatenate((a, a))
+        warning_raised = False
+        with warnings.catch_warnings():
+            warnings.filterwarnings('error')
+            try:
+                check_for_ties(sample)
+            except Warning:
+                warning_raised = True
+        self.assertTrue(warning_raised)
+
+        sample = a
+        warning_raised = False
+        with warnings.catch_warnings():
+            warnings.filterwarnings('error')
+            try:
+                check_for_ties(sample)
+            except Warning:
+                warning_raised = True
+        self.assertFalse(warning_raised)
+
+    def test_check_dimensionality_for_eqpb_1d(self):
+        data_sample = np.linspace(0, 1, 10)
+        reference_sample = np.linspace(0, 1, 20)
+        n_partitions = 4
+        order = None
+        
+        error_raised = False
+        try:
+            check_dimensionality_for_eqpb(data_sample=data_sample,
+                                          reference_sample=reference_sample,
+                                          n_partitions=n_partitions,
+                                          order=order)
+        except AssertionError:
+            error_raised = True
+        self.assertFalse(error_raised)
+
+        error_raised = False
+        reference_sample = np.vstack((np.linspace(0, 1, 20),
+                                      np.linspace(0, 1, 20))).T
+        try:
+            check_dimensionality_for_eqpb(data_sample=data_sample,
+                                          reference_sample=reference_sample,
+                                          n_partitions=n_partitions,
+                                          order=order)
+        except AssertionError:
+            error_raised = True
+        self.assertTrue(error_raised)
+
+    def test_check_dimensionality_for_eqpb_2d(self):
+        data_sample = np.vstack((np.linspace(0, 1, 10),
+                                 np.linspace(0, 1, 10))).T
+        reference_sample = np.vstack((np.linspace(0, 1, 20),
+                                      np.linspace(0, 1, 20))).T
+        n_partitions = [2, 2]
+        order = None
+
+        error_raised = False
+        try:
+            check_dimensionality_for_eqpb(data_sample=data_sample,
+                                          reference_sample=reference_sample,
+                                          n_partitions=n_partitions,
+                                          order=order)
+        except AssertionError:
+            error_raised = True
+        self.assertFalse(error_raised)
+
+        error_raised = False
+        reference_sample = np.vstack((np.linspace(0, 1, 20),
+                                      np.linspace(0, 1, 20),
+                                      np.linspace(0, 1, 20))).T
+        try:
+            check_dimensionality_for_eqpb(data_sample=data_sample,
+                                          reference_sample=reference_sample,
+                                          n_partitions=n_partitions,
+                                          order=order)
+        except AssertionError:
+            error_raised = True
+        self.assertTrue(error_raised)


### PR DESCRIPTION
This PR is a collection of a number of minor bug fixes and improvements:

### Equiprobable Binning
- Assert meaningful dimensions for inputs of equiprobable binning (closes #40)
- Add a check, which raises a warning when the reference sample includes ties (this can lead to non-equiprobable bins, as spotted by @WenzDaniel)
- Fix the bug of changing `bin_edges` in 1D eqpb, when using `plot = True` (also raised by @WenzDaniel)

### Docstring
- Add some hints to readme and docstrings that the computed p-value is only approximate
- Fix some typos

### Other
- Remove python 3.6 support (save some time when running the unittests on github)