### PR TITLE
Add colorbar switch, set 2D histogram x&y limit

### DIFF
--- a/GOFevaluation/utils.py
+++ b/GOFevaluation/utils.py
@@ -354,7 +354,6 @@ def plot_equiprobable_histogram(data_sample, bin_edges, order=None,
                              'be None while plot_mode=\'sigma_deviation\'')
         n_bins = get_n_bins(bin_edges)
         midpoint = nevents_expected / n_bins
-        delta = max(midpoint - ns.min(), ns.max() - midpoint)
         ns = (ns - midpoint) / np.sqrt(midpoint)
         label = (r'$\sigma$-deviation from $\mu_\mathrm{{bin}}$ ='
                  + f'{midpoint:.1f} counts')

--- a/GOFevaluation/utils.py
+++ b/GOFevaluation/utils.py
@@ -436,7 +436,7 @@ def plot_equiprobable_histogram(data_sample, bin_edges, order=None,
         fig = plt.gcf()
 
         extend = 'neither'
-        if norm.vmin > vmin & norm.vmax < vmax:
+        if norm.vmin > vmin and norm.vmax < vmax:
             extend = 'both'
         elif norm.vmin > vmin:
             extend = 'min'

--- a/GOFevaluation/utils.py
+++ b/GOFevaluation/utils.py
@@ -286,8 +286,9 @@ def plot_irregular_binning(ax, bin_edges, order=None, c='k', **kwargs):
 
 
 def plot_equiprobable_histogram(data_sample, bin_edges, order=None,
-                                ax=None, nevents_expected=None, plot_xlim=None,
-                                plot_ylim=None, plot_mode='sigma_deviation',
+                                ax=None, nevents_expected=None,
+                                plot_xlim=None, plot_ylim=None,
+                                plot_mode='sigma_deviation',
                                 draw_colorbar=True, **kwargs):
     """Plot 1d/2d histogram of data sample binned according to the passed
     irregular binning.
@@ -332,7 +333,7 @@ def plot_equiprobable_histogram(data_sample, bin_edges, order=None,
     if plot_mode == 'count_density':
         if (plot_xlim is not None) or (plot_ylim is not None):
             raise RuntimeError('Manually set x or y limit in'
-                            'count_density mode is misleading')
+                               'count_density mode is misleading')
     if plot_xlim is not None:
         xlim = plot_xlim
     if plot_ylim is not None:
@@ -435,7 +436,7 @@ def plot_equiprobable_histogram(data_sample, bin_edges, order=None,
 
         extend = 'neither'
         if norm.vmin > vmin & norm.vmax < vmax:
-            extend='both'
+            extend = 'both'
         elif norm.vmin > vmin:
             extend = 'min'
         elif norm.vmax < vmax:

--- a/GOFevaluation/utils.py
+++ b/GOFevaluation/utils.py
@@ -347,7 +347,7 @@ def plot_equiprobable_histogram(data_sample, bin_edges, order=None,
     be_first = be[0]
     be_second = be[1]
 
-    if(plot_mode == 'sigma_deviation'):
+    if plot_mode == 'sigma_deviation':
         cmap_str = kwargs.pop('cmap', 'RdBu_r')
         cmap = mpl.cm.get_cmap(cmap_str)
         if nevents_expected is None:
@@ -365,14 +365,14 @@ def plot_equiprobable_histogram(data_sample, bin_edges, order=None,
                           stacklevel=2)
         label = (r'$\sigma$-deviation from $\mu_\mathrm{{bin}}$ ='
                  + f'{midpoint:.1f} counts')
-    elif(plot_mode == 'count_density'):
+    elif plot_mode == 'count_density':
         label = r'Counts per area in each bin'
         ns = _get_count_density(ns, be_first, be_second, data_sample)
         cmap_str = kwargs.pop('cmap', 'viridis')
         cmap = mpl.cm.get_cmap(cmap_str)
         vmin = np.min(ns)
         vmax = np.max(ns)
-    elif(plot_mode == 'num_counts'):
+    elif plot_mode == 'num_counts':
         label = r'Number of counts in eace bin'
         cmap_str = kwargs.pop('cmap', 'viridis')
         cmap = mpl.cm.get_cmap(cmap_str)

--- a/GOFevaluation/utils.py
+++ b/GOFevaluation/utils.py
@@ -287,7 +287,8 @@ def plot_irregular_binning(ax, bin_edges, order=None, c='k', **kwargs):
 
 def plot_equiprobable_histogram(data_sample, bin_edges, order=None,
                                 ax=None, nevents_expected=None, plot_xlim=None,
-                                plot_ylim=None, plot_mode='sigma_deviation',
+                                plot_ylim=None, plot_color=None,
+                                plot_mode='sigma_deviation', draw_colorbar=True,
                                 **kwargs):
     """Plot 1d/2d histogram of data sample binned according to the passed
     irregular binning.
@@ -312,13 +313,17 @@ def plot_equiprobable_histogram(data_sample, bin_edges, order=None,
         Can be set to 'num_counts' to plot the total number of counts in each
         bin or 'count_density' to show the counts scaled by the inverse of the
         area of the bin, throws error if set to other value
-    :type plot_mode: string
+    :type plot_mode: string, optional
+    :param draw_colorbar: whether draw the colorbar
+    :type draw_colorbar: bool, optional
     :param plot_xlim: xlim to use for the plot. If None is passed, take min and
         max values of the data sample. Defaults to None.
     :type plot_xlim: tuple, optional
     :param plot_ylim: ylim to use for the plot. If None is passed, take min and
         max values of the data sample. Defaults to None.
     :type plot_ylim: tuple, optional
+    :param plot_color: colorbar range to use for the plot.
+    :type plot_color: tuple, optional
     :raises ValueError: when an unknown order is passed.
     """
     if order is None:
@@ -331,8 +336,6 @@ def plot_equiprobable_histogram(data_sample, bin_edges, order=None,
         xlim = plot_xlim
     if plot_ylim is not None:
         ylim = plot_ylim
-    ax.set_xlim(xlim)
-    ax.set_ylim(ylim)
 
     ns = apply_irregular_binning(data_sample, bin_edges, order=order)
 
@@ -372,6 +375,10 @@ def plot_equiprobable_histogram(data_sample, bin_edges, order=None,
     else:
         raise ValueError(f'plot_mode {plot_mode} is not defined.')
 
+    if plot_color is not None:
+        norm = mpl.colors.Normalize(vmin=plot_color[0],
+                                    vmax=plot_color[1])
+
     if len(data_sample.shape) == 1:
         i = 0
         bin_edges[0] = xlim[0]
@@ -385,9 +392,21 @@ def plot_equiprobable_histogram(data_sample, bin_edges, order=None,
     else:
         # plot rectangle for each bin
         i = 0
+        if order == [0, 1]:
+            be_first[0] = xlim[0]
+            be_first[-1] = xlim[1]
+        elif order == [1, 0]:
+            be_first[0] = ylim[0]
+            be_first[-1] = ylim[1]
         edgecolor = kwargs.get('edgecolor', 'k')
         for low_f, high_f in zip(be_first[:-1], be_first[1:]):
             j = 0
+            if order == [0, 1]:
+                be_second[i][0] = ylim[0]
+                be_second[i][-1] = ylim[1]
+            elif order == [1, 0]:
+                be_second[i][0] = xlim[0]
+                be_second[i][-1] = xlim[1]
             for low_s, high_s in zip(be_second[i][:-1], be_second[i][1:]):
                 if order == [0, 1]:
                     rec = Rectangle((low_f, low_s),
@@ -407,10 +426,14 @@ def plot_equiprobable_histogram(data_sample, bin_edges, order=None,
                 j += 1
             i += 1
 
-    fig = mpl.pyplot.gcf()
+    ax.set_xlim(xlim)
+    ax.set_ylim(ylim)
 
-    fig.colorbar(mpl.cm.ScalarMappable(norm=norm, cmap=cmap), ax=ax,
-                 label=label)
+    if draw_colorbar:
+        fig = mpl.pyplot.gcf()
+
+        fig.colorbar(mpl.cm.ScalarMappable(norm=norm, cmap=cmap), ax=ax,
+                    label=label)
     return
 
 

--- a/GOFevaluation/utils.py
+++ b/GOFevaluation/utils.py
@@ -432,8 +432,11 @@ def plot_equiprobable_histogram(data_sample, bin_edges, order=None,
     if draw_colorbar:
         fig = mpl.pyplot.gcf()
 
-        fig.colorbar(mpl.cm.ScalarMappable(norm=norm, cmap=cmap), ax=ax,
-                    label=label)
+        fig.colorbar(
+            mpl.cm.ScalarMappable(norm=norm, cmap=cmap),
+            ax=ax,
+            label=label,
+        )
     return
 
 

--- a/GOFevaluation/utils.py
+++ b/GOFevaluation/utils.py
@@ -352,14 +352,10 @@ def plot_equiprobable_histogram(data_sample, bin_edges, order=None,
         if nevents_expected is None:
             raise ValueError('nevents_expected cannot ' +
                              'be None while plot_mode=\'sigma_deviation\'')
-
         n_bins = get_n_bins(bin_edges)
         midpoint = nevents_expected / n_bins
         delta = max(midpoint - ns.min(), ns.max() - midpoint)
-        sigma_deviation = delta / np.sqrt(midpoint)
         ns = (ns - midpoint) / np.sqrt(midpoint)
-        vmin = -sigma_deviation
-        vmax = sigma_deviation
         label = (r'$\sigma$-deviation from $\mu_\mathrm{{bin}}$ ='
                  + f'{midpoint:.1f} counts')
     elif(plot_mode == 'count_density'):
@@ -367,16 +363,15 @@ def plot_equiprobable_histogram(data_sample, bin_edges, order=None,
         ns = _get_count_density(ns, be_first, be_second, data_sample)
         cmap_str = kwargs.pop('cmap', 'viridis')
         cmap = mpl.cm.get_cmap(cmap_str)
-        vmin = np.min(ns)
-        vmax = np.max(ns)
     elif(plot_mode == 'num_counts'):
         label = r'Number of counts in eace bin'
         cmap_str = kwargs.pop('cmap', 'viridis')
         cmap = mpl.cm.get_cmap(cmap_str)
-        vmin = np.min(ns)
-        vmax = np.max(ns)
     else:
         raise ValueError(f'plot_mode {plot_mode} is not defined.')
+
+    vmin = np.min(ns)
+    vmax = np.max(ns)
 
     norm = mpl.colors.Normalize(vmin=kwargs.pop('vmin', vmin),
                                 vmax=kwargs.pop('vmax', vmax),

--- a/GOFevaluation/utils.py
+++ b/GOFevaluation/utils.py
@@ -2,6 +2,7 @@ from matplotlib.patches import Rectangle
 from sklearn.preprocessing import KBinsDiscretizer
 import numpy as np
 import matplotlib as mpl
+import matplotlib.pyplot as plt
 
 
 def equiprobable_histogram(data_sample, reference_sample, n_partitions,
@@ -327,7 +328,7 @@ def plot_equiprobable_histogram(data_sample, bin_edges, order=None,
     if order is None:
         order = [0, 1]
     if ax is None:
-        _, ax = mpl.pyplot.subplots(1, figsize=(4, 4))
+        _, ax = plt.subplots(1, figsize=(4, 4))
     if (plot_xlim is None) or (plot_ylim is None):
         xlim, ylim = get_plot_limits(data_sample)
     if plot_mode == 'count_density':
@@ -432,7 +433,7 @@ def plot_equiprobable_histogram(data_sample, bin_edges, order=None,
     ax.set_ylim(ylim)
 
     if draw_colorbar:
-        fig = mpl.pyplot.gcf()
+        fig = plt.gcf()
 
         extend = 'neither'
         if norm.vmin > vmin & norm.vmax < vmax:

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -8,15 +8,16 @@ from GOFevaluation.utils import plot_equiprobable_histogram
 
 class TestPlotEqualProbable(unittest.TestCase):
     def test_plot_arguments(self):
-        n_events = 1000
-        data_sample = sps.uniform(-3, 3).rvs(size=[n_events, 2])
-        x = sps.norm().rvs(size=n_events)
-        y = sps.uniform(-3, 3).rvs(size=n_events)
+        n_data = 100
+        n_reference = 1000
+        data_sample = sps.uniform(-3, 3).rvs(size=[n_data, 2])
+        x = sps.norm().rvs(size=n_reference)
+        y = sps.uniform(-3, 3).rvs(size=n_reference)
         reference_sample = np.stack([x, y]).T
 
         n_partitions = [5, 3]
         order = [0, 1]
-        nevents_expected = sps.poisson(mu=n_events)
+        nevents_expected = sps.poisson(mu=n_data)
         pdf, bin_edges = equiprobable_histogram(data_sample,
                                                 reference_sample,
                                                 n_partitions,

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -9,7 +9,7 @@ from GOFevaluation.utils import plot_equiprobable_histogram
 class TestPlotEqualProbable(unittest.TestCase):
     def test_plot_arguments(self):
         n_data = 100
-        n_reference = 1000
+        n_reference = 10000
         data_sample = sps.uniform(-3, 3).rvs(size=[n_data, 2])
         x = sps.norm().rvs(size=n_reference)
         y = sps.uniform(-3, 3).rvs(size=n_reference)
@@ -17,7 +17,7 @@ class TestPlotEqualProbable(unittest.TestCase):
 
         n_partitions = [5, 3]
         order = [0, 1]
-        nevents_expected = sps.poisson(mu=n_data)
+        nevents_expected = sps.poisson(mu=n_data).rvs()
         pdf, bin_edges = equiprobable_histogram(data_sample,
                                                 reference_sample,
                                                 n_partitions,

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -1,0 +1,73 @@
+import scipy.stats as sps
+import numpy as np
+import unittest
+
+from GOFevaluation.utils import equiprobable_histogram
+from GOFevaluation.utils import plot_equiprobable_histogram
+
+
+class TestPlotEqualProbable(unittest.TestCase):
+    def test_plot_arguments(self):
+        n_events = 1000
+        data_sample = sps.uniform(-3, 3).rvs(size=[n_events, 2])
+        x = sps.norm().rvs(size=n_events)
+        y = sps.uniform(-3, 3).rvs(size=n_events)
+        reference_sample = np.stack([x, y]).T
+
+        n_partitions = [5, 3]
+        order = [0, 1]
+        nevents_expected = sps.poisson(mu=n_events)
+        pdf, bin_edges = equiprobable_histogram(data_sample, reference_sample, n_partitions,
+                            order=order, plot=False)
+        pdf /= np.sum(pdf)
+
+        kwargs = {}
+        plot_equiprobable_histogram(data_sample=data_sample,
+                                    bin_edges=bin_edges,
+                                    order=order,
+                                    nevents_expected=nevents_expected,
+                                    plot_mode='sigma_deviation',
+                                    **kwargs)
+
+        kwargs = {'vmin': -3, 'vmax': 3}
+        plot_xlim = [-3, 3]
+        plot_ylim = [-3, 3]
+        plot_equiprobable_histogram(data_sample=data_sample,
+                                    bin_edges=bin_edges,
+                                    order=order,
+                                    nevents_expected=nevents_expected,
+                                    plot_xlim=plot_xlim,
+                                    plot_ylim=plot_ylim,
+                                    plot_mode='sigma_deviation',
+                                    **kwargs)
+
+        kwargs = {'vmin': -1, 'vmax': 1}
+        plot_xlim = [-1, 1]
+        plot_ylim = [-1, 1]
+        plot_equiprobable_histogram(data_sample=data_sample,
+                                    bin_edges=bin_edges,
+                                    order=order,
+                                    nevents_expected=nevents_expected,
+                                    plot_xlim=plot_xlim,
+                                    plot_ylim=plot_ylim,
+                                    plot_mode='sigma_deviation',
+                                    **kwargs)
+
+        try:
+            error_raised = True
+            plot_equiprobable_histogram(data_sample=data_sample,
+                                        bin_edges=bin_edges,
+                                        order=order,
+                                        nevents_expected=nevents_expected,
+                                        plot_xlim=plot_xlim,
+                                        plot_ylim=plot_ylim,
+                                        plot_mode='count_density',
+                                        **kwargs)
+            error_raised = False
+        except:
+            if not error_raised:
+                raise RuntimeError('Should raise error when count_density'
+                                'mode with x or y limit specified')
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -8,22 +8,22 @@ from GOFevaluation.utils import plot_equiprobable_histogram
 
 class TestPlotEqualProbable(unittest.TestCase):
     def test_plot_arguments(self):
-        n_data = 100
-        n_reference = 10000
-        data_sample = sps.uniform(-3, 3).rvs(size=[n_data, 2])
+        n_data = 10
+        n_reference = 100
+        data_sample = sps.uniform(-3, 6).rvs(size=[n_data, 2])
         x = sps.norm().rvs(size=n_reference)
-        y = sps.uniform(-3, 3).rvs(size=n_reference)
+        y = sps.uniform(-3, 6).rvs(size=n_reference)
         reference_sample = np.stack([x, y]).T
 
         n_partitions = [5, 3]
-        order = [0, 1]
         nevents_expected = sps.poisson(mu=n_data).rvs()
-        pdf, bin_edges = equiprobable_histogram(data_sample,
-                                                reference_sample,
-                                                n_partitions,
-                                                order=order,
-                                                plot=False)
-        pdf /= np.sum(pdf)
+
+        order = [0, 1]
+        _, bin_edges = equiprobable_histogram(data_sample,
+                                            reference_sample,
+                                            n_partitions,
+                                            order=order,
+                                            plot=False)
 
         kwargs = {}
         plot_equiprobable_histogram(data_sample=data_sample,
@@ -33,7 +33,6 @@ class TestPlotEqualProbable(unittest.TestCase):
                                     plot_mode='sigma_deviation',
                                     **kwargs)
 
-        kwargs = {'vmin': -3, 'vmax': 3}
         plot_xlim = [-3, 3]
         plot_ylim = [-3, 3]
         plot_equiprobable_histogram(data_sample=data_sample,
@@ -45,9 +44,7 @@ class TestPlotEqualProbable(unittest.TestCase):
                                     plot_mode='sigma_deviation',
                                     **kwargs)
 
-        kwargs = {'vmin': -1, 'vmax': 1}
-        plot_xlim = [-1, 1]
-        plot_ylim = [-1, 1]
+        kwargs = {'vmin': -3, 'vmax': 3}
         plot_equiprobable_histogram(data_sample=data_sample,
                                     bin_edges=bin_edges,
                                     order=order,
@@ -55,6 +52,30 @@ class TestPlotEqualProbable(unittest.TestCase):
                                     plot_xlim=plot_xlim,
                                     plot_ylim=plot_ylim,
                                     plot_mode='sigma_deviation',
+                                    **kwargs)
+
+        order = [1, 0]
+        _, bin_edges = equiprobable_histogram(data_sample,
+                                            reference_sample,
+                                            n_partitions,
+                                            order=order,
+                                            plot=False)
+
+        kwargs = {'vmin': -1, 'vmax': 1}
+        plot_equiprobable_histogram(data_sample=data_sample,
+                                    bin_edges=bin_edges,
+                                    order=order,
+                                    nevents_expected=nevents_expected,
+                                    plot_xlim=plot_xlim,
+                                    plot_ylim=plot_ylim,
+                                    plot_mode='num_counts',
+                                    **kwargs)
+
+        plot_equiprobable_histogram(data_sample=data_sample,
+                                    bin_edges=bin_edges,
+                                    order=order,
+                                    nevents_expected=nevents_expected,
+                                    plot_mode='count_density',
                                     **kwargs)
 
         try:
@@ -71,7 +92,7 @@ class TestPlotEqualProbable(unittest.TestCase):
         except Exception:
             if not error_raised:
                 raise RuntimeError('Should raise error when count_density'
-                                   'mode with x or y limit specified')
+                                'mode with x or y limit specified')
 
 
 if __name__ == "__main__":

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -44,6 +44,16 @@ class TestPlotEqualProbable(unittest.TestCase):
                                     plot_mode='sigma_deviation',
                                     **kwargs)
 
+        kwargs = {'vmin': -1, 'vmax': 2}
+        plot_equiprobable_histogram(data_sample=data_sample,
+                                    bin_edges=bin_edges,
+                                    order=order,
+                                    nevents_expected=nevents_expected,
+                                    plot_xlim=plot_xlim,
+                                    plot_ylim=plot_ylim,
+                                    plot_mode='sigma_deviation',
+                                    **kwargs)
+
         kwargs = {'vmin': -3, 'vmax': 3}
         plot_equiprobable_histogram(data_sample=data_sample,
                                     bin_edges=bin_edges,

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -17,8 +17,11 @@ class TestPlotEqualProbable(unittest.TestCase):
         n_partitions = [5, 3]
         order = [0, 1]
         nevents_expected = sps.poisson(mu=n_events)
-        pdf, bin_edges = equiprobable_histogram(data_sample, reference_sample, n_partitions,
-                            order=order, plot=False)
+        pdf, bin_edges = equiprobable_histogram(data_sample,
+                                                reference_sample,
+                                                n_partitions,
+                                                order=order,
+                                                plot=False)
         pdf /= np.sum(pdf)
 
         kwargs = {}
@@ -64,10 +67,11 @@ class TestPlotEqualProbable(unittest.TestCase):
                                         plot_mode='count_density',
                                         **kwargs)
             error_raised = False
-        except:
+        except Exception:
             if not error_raised:
                 raise RuntimeError('Should raise error when count_density'
-                                'mode with x or y limit specified')
+                                   'mode with x or y limit specified')
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -20,10 +20,10 @@ class TestPlotEqualProbable(unittest.TestCase):
 
         order = [0, 1]
         _, bin_edges = equiprobable_histogram(data_sample,
-                                            reference_sample,
-                                            n_partitions,
-                                            order=order,
-                                            plot=False)
+                                              reference_sample,
+                                              n_partitions,
+                                              order=order,
+                                              plot=False)
 
         kwargs = {}
         plot_equiprobable_histogram(data_sample=data_sample,
@@ -56,10 +56,10 @@ class TestPlotEqualProbable(unittest.TestCase):
 
         order = [1, 0]
         _, bin_edges = equiprobable_histogram(data_sample,
-                                            reference_sample,
-                                            n_partitions,
-                                            order=order,
-                                            plot=False)
+                                              reference_sample,
+                                              n_partitions,
+                                              order=order,
+                                              plot=False)
 
         kwargs = {'vmin': -1, 'vmax': 1}
         plot_equiprobable_histogram(data_sample=data_sample,
@@ -92,7 +92,7 @@ class TestPlotEqualProbable(unittest.TestCase):
         except Exception:
             if not error_raised:
                 raise RuntimeError('Should raise error when count_density'
-                                'mode with x or y limit specified')
+                                   'mode with x or y limit specified')
 
 
 if __name__ == "__main__":

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -109,9 +109,9 @@ class TestEqpb(unittest.TestCase):
             self.assertEqual(np.shape(n), np.shape(count_density))
             for i in range(0, len(edges[0]) - 1):
                 for j in range(0, len(edges[1][i]) - 1):
-                    if(order == [0, 1]):
+                    if order == [0, 1]:
                         self.assertAlmostEqual(1, count_density[i][j],
                                                places=12)
-                    elif(order == [1, 0]):
+                    elif order == [1, 0]:
                         self.assertAlmostEqual(1, count_density[i][j],
                                                places=12)


### PR DESCRIPTION
1. Add a bool `draw_colorbar` to determine whether draw colorbar
2. Manually set colorbar range, by `plot_color`
3. Set x & y limit in the plot, if draw 2D equal probability histogram. Otherwise, there will be vacuum areas where the `Rectangle` will not cover

I guess these changes will not affect users who are already familiar with previous codes. 