### PR TITLE
Should throw error when count_density mode with x or y limit specified

### DIFF
--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -100,6 +100,9 @@ class TestPlotEqualProbable(unittest.TestCase):
                                         **kwargs)
             error_raised = False
         except Exception:
+            print('Error correctly raised when count_density'
+                  'mode with x or y limit specified')
+        else:
             if not error_raised:
                 raise RuntimeError('Should raise error when count_density'
                                    'mode with x or y limit specified')


### PR DESCRIPTION
If not using `try/except/pass`, the current test in master will not throw an error even if the lines under `try` run without error. This wrong test was introduced by c3085a7ed747be774735a423122588bf98c77b39. 