### PR TITLE
Open right side of the bin to follow numpy convention

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         language_version: python3.9
 
 -   repo: https://github.com/pycqa/docformatter
-    rev: v1.7.5
+    rev: master
     hooks:
     -   id: docformatter
 

--- a/GOFevaluation/utils.py
+++ b/GOFevaluation/utils.py
@@ -273,7 +273,7 @@ def get_equiprobable_binning(
         # Get binning in second dimension (for each bin in first dimension):
         bin_edges_second = []
         for low, high in zip(bin_edges_first[:-1], bin_edges_first[1:]):
-            mask = (first > low) & (first <= high)
+            mask = (first >= low) & (first < high)
             if weights_flag:
                 bin_edges = _weighted_equi(
                     n_partitions[order[1]], second[mask], reference_sample_weights[mask]
@@ -333,7 +333,7 @@ def apply_irregular_binning(data_sample, bin_edges, order=None, data_sample_weig
         ns = []
         i = 0
         for low, high in zip(bin_edges[0][:-1], bin_edges[0][1:]):
-            mask = (first > low) & (first <= high)
+            mask = (first >= low) & (first < high)
             if weights_flag:
                 n, _ = np.histogram(
                     second[mask], bins=bin_edges[1][i], weights=data_sample_weights[mask.flatten()]

--- a/tests/test_evaluators_nd.py
+++ b/tests/test_evaluators_nd.py
@@ -90,8 +90,8 @@ class TestBinnedPoissonChi2GOF(unittest.TestCase):
         reference_sample = np.linspace(0, 1, int(10 * n_data))
         reference_sample = np.vstack([reference_sample for i in range(2)]).T
 
-        binned_data = np.full(n_partitions, n_data / np.product(n_partitions))
-        binned_reference = np.full(n_partitions, n_expected / np.product(n_partitions))
+        binned_data = np.full(n_partitions, n_data / np.prod(n_partitions))
+        binned_reference = np.full(n_partitions, n_expected / np.prod(n_partitions))
         gofclass_from_binned = BinnedPoissonChi2GOF.from_binned(binned_data, binned_reference)
         gof_from_binned = gofclass_from_binned.get_gof()
 
@@ -295,8 +295,8 @@ class TestBinnedChi2GOF(unittest.TestCase):
         reference_sample = np.linspace(0, 1, int(10 * n_data))
         reference_sample = np.vstack([reference_sample for i in range(2)]).T
 
-        binned_data = np.full(n_partitions, n_data / np.product(n_partitions))
-        binned_reference = np.full(n_partitions, n_expected / np.product(n_partitions))
+        binned_data = np.full(n_partitions, n_data / np.prod(n_partitions))
+        binned_reference = np.full(n_partitions, n_expected / np.prod(n_partitions))
         gofclass_from_binned = BinnedChi2GOF.from_binned(binned_data, binned_reference)
         gof_from_binned = gofclass_from_binned.get_gof()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -87,7 +87,7 @@ class TestEqpb(unittest.TestCase):
             )
             self.assertEqual(np.sum(n), n_data)
             for expect in n.reshape(-1):
-                self.assertEqual(expect, n_data / np.product(n_partitions))
+                self.assertEqual(expect, n_data / np.prod(n_partitions))
             self.assertEqual(np.shape(bin_edges[0])[0] - 1, n_partitions[order[0]])
             self.assertEqual(np.shape(bin_edges[1])[0], n_partitions[order[0]])
             self.assertEqual(np.shape(bin_edges[1])[1] - 1, n_partitions[order[1]])


### PR DESCRIPTION
For `numpy.histogram`,
```
All but the last (righthand-most) bin is half-open. In other words, if bins is:

[1, 2, 3, 4]
then the first bin is [1, 2) (including 1, but excluding 2) and the second [2, 3). The last bin, however, is [3, 4], which includes 4.
```

For `numpy.digitize`,
```
Return the indices of the bins to which each value in input array belongs.
right | order of bins | returned index i satisfies
False | increasing | bins[i-1] <= x < bins[i]
```

So this PR make the bins right open.

Reference:
1. https://numpy.org/doc/stable/reference/generated/numpy.histogram.html
2. https://numpy.org/doc/stable/reference/generated/numpy.digitize.html