### PR TITLE
Equal probability binning on integer sample

### DIFF
--- a/GOFevaluation/evaluators_1d.py
+++ b/GOFevaluation/evaluators_1d.py
@@ -10,11 +10,10 @@ from GOFevaluation.evaluator_base import EvaluatorBaseSample
 class ADTestTwoSampleGOF(EvaluatorBaseSample):
     """Goodness of Fit based on the two-sample Anderson-Darling Test.
 
-    The test is described in https://www.doi.org/10.1214/aoms/1177706788 and
-    https://www.doi.org/10.2307/2288805.
-    It test if two samples    come from the same pdf. Similar to
-    :class:`KSTestTwoSampleGOF` but more    weight is given on tail differences due to
-    a different weighting function.
+    The test is described in https://www.doi.org/10.1214/aoms/1177706788
+    and https://www.doi.org/10.2307/2288805. It test if two samples
+    come from the same pdf. Similar to `KSTestTwoSampleGOF` but more
+    weight is given on tail differences due to a different weighting function.
 
     :param data_sample: sample of unbinned data
     :type data_sample: array_like, 1-Dimensional

--- a/GOFevaluation/evaluators_1d.py
+++ b/GOFevaluation/evaluators_1d.py
@@ -12,9 +12,8 @@ class ADTestTwoSampleGOF(EvaluatorBaseSample):
 
     The test is described in https://www.doi.org/10.1214/aoms/1177706788 and
     https://www.doi.org/10.2307/2288805.
-    It test if two samples come from the same pdf. Similar to `KSTestTwoSampleGOF`
-    but more weight is given on tail differences due to a different weighting
-    function.
+     It test if two samples come from the same pdf. Similar to `KSTestTwoSampleGOF` but
+    more weight is given on tail differences due to a different weighting function.
 
     :param data_sample: sample of unbinned data
     :type data_sample: array_like, 1-Dimensional

--- a/GOFevaluation/evaluators_1d.py
+++ b/GOFevaluation/evaluators_1d.py
@@ -12,7 +12,7 @@ class ADTestTwoSampleGOF(EvaluatorBaseSample):
 
     The test is described in https://www.doi.org/10.1214/aoms/1177706788 and
     https://www.doi.org/10.2307/2288805.
-     It test if two samples come from the same pdf. Similar to
+      It test if two samples come from the same pdf. Similar to
     :class:`KSTestTwoSampleGOF` but more    weight is given on tail differences due to
     a different weighting function.
 

--- a/GOFevaluation/evaluators_1d.py
+++ b/GOFevaluation/evaluators_1d.py
@@ -10,10 +10,11 @@ from GOFevaluation.evaluator_base import EvaluatorBaseSample
 class ADTestTwoSampleGOF(EvaluatorBaseSample):
     """Goodness of Fit based on the two-sample Anderson-Darling Test.
 
-    The test is described in https://www.doi.org/10.1214/aoms/1177706788
-    and https://www.doi.org/10.2307/2288805. It test if two samples
-    come from the same pdf. Similar to :class:`KSTestTwoSampleGOF` but more
-    weight is given on tail differences due to a different weighting function.
+    The test is described in https://www.doi.org/10.1214/aoms/1177706788 and
+    https://www.doi.org/10.2307/2288805.
+    It test if two samples    come from the same pdf. Similar to
+    :class:`KSTestTwoSampleGOF` but more    weight is given on tail differences due to
+    a different weighting function.
 
     :param data_sample: sample of unbinned data
     :type data_sample: array_like, 1-Dimensional

--- a/GOFevaluation/evaluators_1d.py
+++ b/GOFevaluation/evaluators_1d.py
@@ -14,7 +14,7 @@ class ADTestTwoSampleGOF(EvaluatorBaseSample):
     more weight is given on tail differences due to a different weighting function. The
     test is described in
     https://www.doi.org/10.1214/aoms/1177706788
-    and https://www.doi.org/10.2307/2288805.
+     and https://www.doi.org/10.2307/2288805.
 
     :param data_sample: sample of unbinned data
     :type data_sample: array_like, 1-Dimensional

--- a/GOFevaluation/evaluators_1d.py
+++ b/GOFevaluation/evaluators_1d.py
@@ -10,11 +10,10 @@ from GOFevaluation.evaluator_base import EvaluatorBaseSample
 class ADTestTwoSampleGOF(EvaluatorBaseSample):
     """Goodness of Fit based on the two-sample Anderson-Darling Test.
 
-    The test is described in https://www.doi.org/10.1214/aoms/1177706788 and
-    https://www.doi.org/10.2307/2288805.
-      It test if two samples come from the same pdf. Similar to
-    :class:`KSTestTwoSampleGOF` but more    weight is given on tail differences due to
-    a different weighting function.
+    The test is described in https://www.doi.org/10.1214/aoms/1177706788
+    and https://www.doi.org/10.2307/2288805. It test if two samples
+    come from the same pdf. Similar to :class:`KSTestTwoSampleGOF` but more
+    weight is given on tail differences due to a different weighting function.
 
     :param data_sample: sample of unbinned data
     :type data_sample: array_like, 1-Dimensional

--- a/GOFevaluation/evaluators_1d.py
+++ b/GOFevaluation/evaluators_1d.py
@@ -11,9 +11,10 @@ class ADTestTwoSampleGOF(EvaluatorBaseSample):
     """Goodness of Fit based on the two-sample Anderson-Darling Test.
 
     It test if two samples come from the same pdf. Similar to `KSTestTwoSampleGOF` but
-    more weight is given on tail differences due to a different weighting function.
-    The test is described in https://www.doi.org/10.1214/aoms/1177706788 and
-    https://www.doi.org/10.2307/2288805.
+    more weight is given on tail differences due to a different weighting function. The
+    test is described in
+    https://www.doi.org/10.1214/aoms/1177706788
+    and    https://www.doi.org/10.2307/2288805.
 
     :param data_sample: sample of unbinned data
     :type data_sample: array_like, 1-Dimensional

--- a/GOFevaluation/evaluators_1d.py
+++ b/GOFevaluation/evaluators_1d.py
@@ -10,11 +10,11 @@ from GOFevaluation.evaluator_base import EvaluatorBaseSample
 class ADTestTwoSampleGOF(EvaluatorBaseSample):
     """Goodness of Fit based on the two-sample Anderson-Darling Test.
 
-    The test is described in https://www.doi.org/10.1214/aoms/1177706788
-    and https://www.doi.org/10.2307/2288805. It test if two samples
-    come from the same pdf. Similar to :class:`KSTestTwoSampleGOF` but more
-    weight is given on tail differences due to a different weighting function.
-
+    The test is described in https://www.doi.org/10.1214/aoms/1177706788 and
+    https://www.doi.org/10.2307/2288805.
+    It test if two samples    come from the same pdf. Similar to
+    :class:`KSTestTwoSampleGOF` but more    weight is given on tail differences due to
+    a different weighting function.
 
     :param data_sample: sample of unbinned data
     :type data_sample: array_like, 1-Dimensional
@@ -87,8 +87,8 @@ class KSTestGOF(EvaluatorBasePdf):
     def get_gof(self):
         """GOF is calculated using current class attributes.
 
-        The CDF is interpolated from pdf and binning. The gof is then
-        calculated by `sps.kstest`
+        The CDF is interpolated from pdf and binning. The gof is then calculated by
+        `sps.kstest`
 
         :return: Goodness of Fit
         :rtype: float

--- a/GOFevaluation/evaluators_1d.py
+++ b/GOFevaluation/evaluators_1d.py
@@ -12,8 +12,8 @@ class ADTestTwoSampleGOF(EvaluatorBaseSample):
 
     The test is described in https://www.doi.org/10.1214/aoms/1177706788 and
     https://www.doi.org/10.2307/2288805.
-    It test if two samples    come from the same pdf. Similar to `KSTestTwoSampleGOF`
-    but more    weight is given on tail differences due to a different weighting
+    It test if two samples come from the same pdf. Similar to `KSTestTwoSampleGOF`
+    but more weight is given on tail differences due to a different weighting
     function.
 
     :param data_sample: sample of unbinned data

--- a/GOFevaluation/evaluators_1d.py
+++ b/GOFevaluation/evaluators_1d.py
@@ -10,10 +10,11 @@ from GOFevaluation.evaluator_base import EvaluatorBaseSample
 class ADTestTwoSampleGOF(EvaluatorBaseSample):
     """Goodness of Fit based on the two-sample Anderson-Darling Test.
 
-    The test is described in https://www.doi.org/10.1214/aoms/1177706788
-    and https://www.doi.org/10.2307/2288805. It test if two samples
-    come from the same pdf. Similar to `KSTestTwoSampleGOF` but more
-    weight is given on tail differences due to a different weighting function.
+    The test is described in https://www.doi.org/10.1214/aoms/1177706788 and
+    https://www.doi.org/10.2307/2288805.
+    It test if two samples    come from the same pdf. Similar to `KSTestTwoSampleGOF`
+    but more    weight is given on tail differences due to a different weighting
+    function.
 
     :param data_sample: sample of unbinned data
     :type data_sample: array_like, 1-Dimensional

--- a/GOFevaluation/evaluators_1d.py
+++ b/GOFevaluation/evaluators_1d.py
@@ -10,7 +10,7 @@ from GOFevaluation.evaluator_base import EvaluatorBaseSample
 class ADTestTwoSampleGOF(EvaluatorBaseSample):
     """Goodness of Fit based on the two-sample Anderson-Darling Test.
 
-    It test if two samples come from the same pdf. Similar to `KSTestTwoSampleGOF` but
+    It tests if two samples come from the same pdf. Similar to `KSTestTwoSampleGOF` but
     more weight is given on tail differences due to a different weighting function. The
     test is described in
     https://www.doi.org/10.1214/aoms/1177706788

--- a/GOFevaluation/evaluators_1d.py
+++ b/GOFevaluation/evaluators_1d.py
@@ -12,7 +12,7 @@ class ADTestTwoSampleGOF(EvaluatorBaseSample):
 
     The test is described in https://www.doi.org/10.1214/aoms/1177706788 and
     https://www.doi.org/10.2307/2288805.
-    It test if two samples    come from the same pdf. Similar to
+     It test if two samples    come from the same pdf. Similar to
     :class:`KSTestTwoSampleGOF` but more    weight is given on tail differences due to
     a different weighting function.
 

--- a/GOFevaluation/evaluators_1d.py
+++ b/GOFevaluation/evaluators_1d.py
@@ -10,10 +10,10 @@ from GOFevaluation.evaluator_base import EvaluatorBaseSample
 class ADTestTwoSampleGOF(EvaluatorBaseSample):
     """Goodness of Fit based on the two-sample Anderson-Darling Test.
 
+    It test if two samples come from the same pdf. Similar to `KSTestTwoSampleGOF` but
+    more weight is given on tail differences due to a different weighting function.
     The test is described in https://www.doi.org/10.1214/aoms/1177706788 and
     https://www.doi.org/10.2307/2288805.
-     It test if two samples come from the same pdf. Similar to `KSTestTwoSampleGOF` but
-    more weight is given on tail differences due to a different weighting function.
 
     :param data_sample: sample of unbinned data
     :type data_sample: array_like, 1-Dimensional

--- a/GOFevaluation/evaluators_1d.py
+++ b/GOFevaluation/evaluators_1d.py
@@ -14,7 +14,7 @@ class ADTestTwoSampleGOF(EvaluatorBaseSample):
     more weight is given on tail differences due to a different weighting function. The
     test is described in
     https://www.doi.org/10.1214/aoms/1177706788
-    and    https://www.doi.org/10.2307/2288805.
+    and https://www.doi.org/10.2307/2288805.
 
     :param data_sample: sample of unbinned data
     :type data_sample: array_like, 1-Dimensional

--- a/GOFevaluation/evaluators_1d.py
+++ b/GOFevaluation/evaluators_1d.py
@@ -12,7 +12,7 @@ class ADTestTwoSampleGOF(EvaluatorBaseSample):
 
     The test is described in https://www.doi.org/10.1214/aoms/1177706788 and
     https://www.doi.org/10.2307/2288805.
-     It test if two samples    come from the same pdf. Similar to
+    It test if two samples come from the same pdf. Similar to
     :class:`KSTestTwoSampleGOF` but more    weight is given on tail differences due to
     a different weighting function.
 

--- a/GOFevaluation/evaluators_1d.py
+++ b/GOFevaluation/evaluators_1d.py
@@ -12,7 +12,7 @@ class ADTestTwoSampleGOF(EvaluatorBaseSample):
 
     The test is described in https://www.doi.org/10.1214/aoms/1177706788 and
     https://www.doi.org/10.2307/2288805.
-    It test if two samples come from the same pdf. Similar to
+     It test if two samples come from the same pdf. Similar to
     :class:`KSTestTwoSampleGOF` but more    weight is given on tail differences due to
     a different weighting function.
 

--- a/GOFevaluation/evaluators_nd.py
+++ b/GOFevaluation/evaluators_nd.py
@@ -246,8 +246,9 @@ class PointToPointGOF(EvaluatorBaseSample):
         return d_min
 
     def weighting_function(self, d, d_min):
-        """Weigh distances d according to log profile. Pole at d = 0 is omitted by
-        introducing d_min that replaces the distance for d < d_min.
+        """Weigh distances d according to log profile.
+
+        Pole at d = 0 is omitted by introducing d_min that replaces the distance for d < d_min.
 
         :param d_min: Replaces the distance for distance d < d_min.
             If None, d_min is estimated by :func:`get_dmin`

--- a/GOFevaluation/evaluators_nd.py
+++ b/GOFevaluation/evaluators_nd.py
@@ -270,7 +270,6 @@ class PointToPointGOF(EvaluatorBaseSample):
     def calculate_gof(self, data_sample, reference_sample, d_min=None):
         """Internal function to calculate gof for :func:`get_gof` and
         :func:`get_pvalue`"""
-
         nevents_data = np.shape(data_sample)[0]
         nevents_ref = np.shape(reference_sample)[0]
 
@@ -307,7 +306,6 @@ class PointToPointGOF(EvaluatorBaseSample):
             the region of highest density
 
         """
-
         gof = self.calculate_gof(self.data_sample, self.reference_sample, d_min=d_min)
         self.gof = gof
         return gof
@@ -315,20 +313,18 @@ class PointToPointGOF(EvaluatorBaseSample):
     def get_pvalue(self, n_perm=1000, d_min=None):
         """The approximate p-value is calculated.
 
-        Computes the p-value by means of re-sampling data sample
-        and reference sample. For each re-sampling, the gof is calculated.
-        The p-value can then be obtained from the distribution of these
-        fake-gofs.
+        Computes the p-value by means of re-sampling data sample and reference sample.
+        For each re-sampling, the gof is calculated. The p-value can then be obtained
+        from the distribution of these fake-gofs.
 
-        Note that this is only an approximate method, since the model is not
-        refitted to the re-sampled data. Especially with low statistics and
-        many fit parameters, this can introduce a bias towards larger p-values.
+        Note that this is only an approximate method, since the model is not refitted
+        to the re-sampled data. Especially with low statistics and many fit parameters,
+        this can introduce a bias towards larger p-values.
 
         :param n_perm: Number of fake-gofs calculated, defaults to 1000
         :type n_perm: int, optional
-        :param d_min: Replaces the distance for distance d < d_min.
-            If None, d_min is estimated by :func:`get_dmin`,
-            defaults to None
+        :param d_min: Replaces the distance for distance d < d_min. If None, d_min is
+            estimated by :func:`get_dmin`, defaults to None
         :type d_min: float, optional
         :return: p-value
         :rtype: float

--- a/GOFevaluation/utils.py
+++ b/GOFevaluation/utils.py
@@ -220,9 +220,10 @@ def _weighted_equi(n_bins, reference_sample, reference_sample_weights, integer=F
 
 
 def _weighted_equi_integer(nbins, reference_sample, reference_sample_weights, left=True):
-    """Perform a 1D equiprobable binning for integer reference_sample with weights. The
-    potential binning between integers are traversed. The frist bin edge is selected if
-    the frist bin size is close to 1 / nbins.
+    """Perform a 1D equiprobable binning for integer reference_sample with weights.
+
+    The potential binning between integers are traversed. The frist bin edge is
+    selected if the frist bin size is close to 1 / nbins.
 
     :param n_bins: number of partitions in this dimension
     :type n_bins: int

--- a/GOFevaluation/utils.py
+++ b/GOFevaluation/utils.py
@@ -332,6 +332,8 @@ def get_equiprobable_binning(
     elif dim == 2:
         if order is None:
             order = [0, 1]
+        if integer is None:
+            integer = [False, False]
         first = reference_sample.T[order[0]]
         second = reference_sample.T[order[1]]
         bin_edges_first = _weighted_equi(
@@ -541,7 +543,7 @@ def plot_equiprobable_histogram(
         xlim, ylim = get_plot_limits(data_sample)
     if plot_mode == "count_density":
         if (plot_xlim is not None) or (plot_ylim is not None):
-            raise RuntimeError("Manually set x or y limit in" "count_density mode is misleading")
+            raise RuntimeError("Manually set x or y limit in count_density mode is misleading")
     if plot_xlim is not None:
         xlim = plot_xlim
     if plot_ylim is not None:
@@ -576,9 +578,9 @@ def plot_equiprobable_histogram(
         cmap_str = kwargs.pop("cmap", "RdBu_r")
         cmap = _get_cmap(cmap_str, alpha=alpha)
         if nevents_expected is None:
-            raise ValueError("nevents_expected cannot " "be None while plot_mode='sigma_deviation'")
+            raise ValueError("nevents_expected cannot be None while plot_mode='sigma_deviation'")
         if reference_sample is None:
-            raise ValueError("reference_sample cannot " "be None while plot_mode='sigma_deviation'")
+            raise ValueError("reference_sample cannot be None while plot_mode='sigma_deviation'")
         ns_expected = nevents_expected * pdf
         ns = (ns - ns_expected) / np.sqrt(ns_expected)
         max_deviation = max(np.abs(ns.ravel()))
@@ -737,17 +739,15 @@ def check_for_ties(sample, dim):
 
 def check_dimensionality_for_eqpb(data_sample, reference_sample, n_partitions, order):
     if len(reference_sample.shape) == 1:
-        assert len(data_sample.shape) == 1, (
-            "Shape of data_sample is" " incompatible with shape of reference_sample"
-        )
-        assert isinstance(n_partitions, int), "n_partitions must be an" " integer for 1-dim. data."
-        assert order is None, (
-            "providing a not-None value for order is" " ambiguous for 1-dim. data."
-        )
+        assert (
+            len(data_sample.shape) == 1
+        ), "Shape of data_sample is incompatible with shape of reference_sample"
+        assert isinstance(n_partitions, int), "n_partitions must be an integer for 1-dim. data."
+        assert order is None, "providing a not-None value for order is ambiguous for 1-dim. data."
     elif len(reference_sample.shape) == 2:
-        assert len(data_sample.shape) == 2, (
-            "Shape of data_sample is" " incompatible with shape of reference_sample."
-        )
+        assert (
+            len(data_sample.shape) == 2
+        ), "Shape of data_sample is incompatible with shape of reference_sample."
         # Check dimensionality is two
         assert data_sample.shape[1] == reference_sample.shape[1] == len(n_partitions), (
             "Shape of data_sample is incompatible with shape of"

--- a/GOFevaluation/utils.py
+++ b/GOFevaluation/utils.py
@@ -762,7 +762,7 @@ def check_dimensionality_for_eqpb(data_sample, reference_sample, n_partitions, o
                 "-dimensional data."
             )
     else:
-        raise TypeError("reference_sample has unsupported shape "  f"{reference_sample.shape}.")
+        raise TypeError(f"reference_sample has unsupported shape {reference_sample.shape}.")
 
 
 def _get_cmap(cmap_str, alpha=1):

--- a/GOFevaluation/utils.py
+++ b/GOFevaluation/utils.py
@@ -187,7 +187,8 @@ def _weighted_equi(n_bins, reference_sample, reference_sample_weights, integer=F
     :param integer: make sure the bin edge is between integers if reference_sample is
         array of integer, defaults to False
     :type integer: bool, optional
-    :param left: if perform left-first search, only used when reference_sample is array of integer
+    :param left: if perform left-first search, only used when reference_sample is array
+        of integer
     :type left: bool, optional
     :return: Returns bin_edges.
     :rtype: array_like, 1-Dimensional
@@ -219,9 +220,9 @@ def _weighted_equi(n_bins, reference_sample, reference_sample_weights, integer=F
 
 
 def _weighted_equi_integer(nbins, reference_sample, reference_sample_weights, left=True):
-    """Perform a 1D equiprobable binning for integer reference_sample with weights.
-    The potential binning between integers are traversed.
-    The frist bin edge is selected if the frist bin size is close to 1 / nbins.
+    """Perform a 1D equiprobable binning for integer reference_sample with weights. The
+    potential binning between integers are traversed. The frist bin edge is selected if
+    the frist bin size is close to 1 / nbins.
 
     :param n_bins: number of partitions in this dimension
     :type n_bins: int
@@ -760,7 +761,7 @@ def check_dimensionality_for_eqpb(data_sample, reference_sample, n_partitions, o
                 "-dimensional data."
             )
     else:
-        raise TypeError("reference_sample has unsupported shape " f"{reference_sample.shape}.")
+        raise TypeError("reference_sample has unsupported shape "  f"{reference_sample.shape}.")
 
 
 def _get_cmap(cmap_str, alpha=1):

--- a/GOFevaluation/utils.py
+++ b/GOFevaluation/utils.py
@@ -394,10 +394,10 @@ def apply_irregular_binning(data_sample, bin_edges, order=None, data_sample_weig
     :rtype: array
 
     """
-    weights_flag = 0
+    weights_flag = 1
     if data_sample_weights is None:
         data_sample_weights = np.ones(len(data_sample))
-        weights_flag = 1
+        weights_flag = 0
     _check_weight_sanity(data_sample, data_sample_weights)
     if len(data_sample.shape) == 1:
         ns, _ = np.histogram(data_sample, bins=bin_edges, weights=data_sample_weights)

--- a/GOFevaluation/utils.py
+++ b/GOFevaluation/utils.py
@@ -14,6 +14,8 @@ def equiprobable_histogram(
     plot=False,
     reference_sample_weights=None,
     data_sample_weights=None,
+    integer=None,
+    left=True,
     **kwargs,
 ):
     """Define equiprobable histogram based on the reference sample and bin the data
@@ -36,6 +38,11 @@ def equiprobable_histogram(
     :type reference_sample_weights: array_like, 1-Dimensional
     :param data_sample_weights: weights of data_sample
     :type data_sample_weights: array_like, 1-Dimensional
+    :param integer: make sure the bin edge is between integers if reference_sample is
+        array of integer, defaults to None
+    :type integer: bool, optional
+    :param left: if perform left-first search, only used when reference_sample is array of integer
+    :type left: bool, optional
     :return: n, bin_edges
         n: number of counts of data sample in each bin
         bin_edges: For order [0, 1]([1, 0])
@@ -53,6 +60,8 @@ def equiprobable_histogram(
         n_partitions=n_partitions,
         order=order,
         reference_sample_weights=reference_sample_weights,
+        integer=integer,
+        left=left,
     )
     n = apply_irregular_binning(
         data_sample=data_sample,
@@ -166,32 +175,7 @@ def _get_count_density(ns, be_first, be_second, data_sample):
     return ns
 
 
-def _equi(n_bins, reference_sample):
-    """Perform a 1D equiprobable binning for reference_sample.
-
-    :param n_bins: number of partitions in this dimension
-    :type n_bins: int
-    :param reference_sample: sample of unbinned reference
-    :type reference_sample: array_like, 1-Dimensional
-    :return: Returns bin_edges.
-    :rtype: array_like, 1-Dimensional
-
-    """
-    if np.unique(reference_sample).size < n_bins:
-        raise ValueError(
-            "Number of unique values in reference_sample "
-            "smaller than n_bins, cannot perform equiprobable binning."
-        )
-    if np.unique(reference_sample).size == n_bins:
-        unique = np.unique(reference_sample)
-        bin_edges = np.hstack([-np.inf, (unique[1:] + unique[:1]) / 2, np.inf])
-        return bin_edges
-    bin_edges = np.quantile(reference_sample, np.linspace(0, 1, n_bins + 1)[1:-1])
-    bin_edges = np.hstack([-np.inf, bin_edges, np.inf])
-    return bin_edges
-
-
-def _weighted_equi(n_bins, reference_sample, reference_sample_weights):
+def _weighted_equi(n_bins, reference_sample, reference_sample_weights, integer=False, left=True):
     """Perform a 1D equiprobable binning for reference_sample with weights.
 
     :param n_bins: number of partitions in this dimension
@@ -200,6 +184,11 @@ def _weighted_equi(n_bins, reference_sample, reference_sample_weights):
     :type reference_sample: array_like, 1-Dimensional
     :param reference_sample_weights: weights of reference_sample
     :type reference_sample_weights: array_like, 1-Dimensional
+    :param integer: make sure the bin edge is between integers if reference_sample is
+        array of integer, defaults to False
+    :type integer: bool, optional
+    :param left: if perform left-first search, only used when reference_sample is array of integer
+    :type left: bool, optional
     :return: Returns bin_edges.
     :rtype: array_like, 1-Dimensional
 
@@ -213,6 +202,10 @@ def _weighted_equi(n_bins, reference_sample, reference_sample_weights):
         unique = np.unique(reference_sample)
         bin_edges = np.hstack([-np.inf, (unique[1:] + unique[:1]) / 2, np.inf])
         return bin_edges
+
+    if integer:
+        return _weighted_equi_integer(n_bins, reference_sample, reference_sample_weights, left=left)
+
     argsort = reference_sample.argsort()
     reference_sample_weights = reference_sample_weights[argsort]
     reference_sample = reference_sample[argsort]
@@ -225,8 +218,66 @@ def _weighted_equi(n_bins, reference_sample, reference_sample_weights):
     return bin_edges
 
 
+def _weighted_equi_integer(nbins, reference_sample, reference_sample_weights, left=True):
+    """Perform a 1D equiprobable binning for integer reference_sample with weights.
+    The potential binning between integers are traversed.
+    The frist bin edge is selected if the frist bin size is close to 1 / nbins.
+
+    :param n_bins: number of partitions in this dimension
+    :type n_bins: int
+    :param reference_sample: sample of unbinned reference
+    :type reference_sample: array_like, 1-Dimensional
+    :param reference_sample_weights: weights of reference_sample
+    :type reference_sample_weights: array_like, 1-Dimensional
+    :param left: if perform left-first search
+    :type left: bool, optional
+    :return: Returns bin_edges.
+    :rtype: array_like, 1-Dimensional
+
+    """
+    if not left:
+        bin_edges = _weighted_equi_integer(nbins, -reference_sample, reference_sample_weights)
+        bin_edges = -bin_edges[::-1]
+        return bin_edges
+
+    normalization = reference_sample_weights.sum()
+    potential_bins = np.unique(reference_sample)[:-1] + 0.5
+
+    if len(potential_bins) == 0:
+        return np.array([-np.inf, np.inf])
+
+    def get_fraction(i):
+        m = reference_sample < potential_bins[i]
+        f = reference_sample_weights[m].sum()
+        f /= normalization
+        return f
+
+    fraction = 1 / nbins
+
+    for i in range(len(potential_bins)):
+        if get_fraction(i) > fraction:
+            break
+        elif i < len(potential_bins) - 1 and get_fraction(i + 1) > fraction:
+            a = abs(get_fraction(i) - fraction)
+            b = abs(get_fraction(i + 1) - fraction)
+            if a < b:
+                break
+    if nbins > 2:
+        m = reference_sample > potential_bins[i]
+        bin_edges = _weighted_equi_integer(
+            nbins - 1, reference_sample[m], reference_sample_weights[m]
+        )
+        return np.hstack([np.array([-np.inf, potential_bins[i]]), bin_edges[1:]])
+    return np.array([-np.inf, potential_bins[i], np.inf])
+
+
 def get_equiprobable_binning(
-    reference_sample, n_partitions, order=None, reference_sample_weights=None
+    reference_sample,
+    n_partitions,
+    order=None,
+    reference_sample_weights=None,
+    integer=None,
+    left=True,
 ):
     """Define an equiprobable binning for the reference sample.
 
@@ -246,6 +297,11 @@ def get_equiprobable_binning(
     :type order: list, optional
     :param reference_sample_weights: weights of reference_sample
     :type reference_sample_weights: array_like, 1-Dimensional
+    :param integer: make sure the bin edge is between integers if reference_sample is
+        array of integer, defaults to None
+    :type integer: bool, optional
+    :param left: if perform left-first search, only used when reference_sample is array of integer
+    :type left: bool, optional
     :return: Returns bin_edges.
         1D: list of bin edges
         2D: For order [0, 1]([1, 0]) these are the bin edges in x(y) and y(x)
@@ -267,37 +323,36 @@ def get_equiprobable_binning(
     check_for_ties(reference_sample, dim=dim)
 
     if reference_sample_weights is None:
-        weights_flag = 0
-    else:
-        _check_weight_sanity(reference_sample, reference_sample_weights)
-        weights_flag = 1
+        reference_sample_weights = np.ones(len(reference_sample))
+    _check_weight_sanity(reference_sample, reference_sample_weights)
     if dim == 1:
-        if weights_flag:
-            bin_edges = _weighted_equi(n_partitions, reference_sample, reference_sample_weights)
-        else:
-            bin_edges = _equi(n_partitions, reference_sample)
+        bin_edges = _weighted_equi(
+            n_partitions, reference_sample, reference_sample_weights, integer=integer, left=left
+        )
     elif dim == 2:
         if order is None:
             order = [0, 1]
         first = reference_sample.T[order[0]]
         second = reference_sample.T[order[1]]
-        if weights_flag:
-            bin_edges_first = _weighted_equi(
-                n_partitions[order[0]], first, reference_sample_weights
-            )
-        else:
-            bin_edges_first = _equi(n_partitions[order[0]], first)
+        bin_edges_first = _weighted_equi(
+            n_partitions[order[0]],
+            first,
+            reference_sample_weights,
+            integer=integer[order[0]],
+            left=left,
+        )
 
         # Get binning in second dimension (for each bin in first dimension):
         bin_edges_second = []
         for low, high in zip(bin_edges_first[:-1], bin_edges_first[1:]):
             mask = (first >= low) & (first < high)
-            if weights_flag:
-                bin_edges = _weighted_equi(
-                    n_partitions[order[1]], second[mask], reference_sample_weights[mask]
-                )
-            else:
-                bin_edges = _equi(n_partitions[order[1]], second[mask])
+            bin_edges = _weighted_equi(
+                n_partitions[order[1]],
+                second[mask],
+                reference_sample_weights[mask],
+                integer=integer[order[1]],
+                left=left,
+            )
             bin_edges_second.append(bin_edges)
         bin_edges_second = np.array(bin_edges_second)
         bin_edges = [bin_edges_first, bin_edges_second]
@@ -335,11 +390,11 @@ def apply_irregular_binning(data_sample, bin_edges, order=None, data_sample_weig
     :rtype: array
 
     """
+    weights_flag = 0
     if data_sample_weights is None:
-        weights_flag = 0
-    else:
-        _check_weight_sanity(data_sample, data_sample_weights)
+        data_sample_weights = np.ones(len(data_sample))
         weights_flag = 1
+    _check_weight_sanity(data_sample, data_sample_weights)
     if len(data_sample.shape) == 1:
         ns, _ = np.histogram(data_sample, bins=bin_edges, weights=data_sample_weights)
     else:
@@ -352,12 +407,9 @@ def apply_irregular_binning(data_sample, bin_edges, order=None, data_sample_weig
         i = 0
         for low, high in zip(bin_edges[0][:-1], bin_edges[0][1:]):
             mask = (first >= low) & (first < high)
-            if weights_flag:
-                n, _ = np.histogram(
-                    second[mask], bins=bin_edges[1][i], weights=data_sample_weights[mask.flatten()]
-                )
-            else:
-                n, _ = np.histogram(second[mask], bins=bin_edges[1][i])
+            n, _ = np.histogram(
+                second[mask], bins=bin_edges[1][i], weights=data_sample_weights[mask.flatten()]
+            )
             ns.append(n)
             i += 1
     if weights_flag:

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,10 @@ setuptools.setup(
     name="GOFevaluation",
     version="0.1.5",
     author="GOFevaluation contributors, the XENON collaboration",
-    description="Evaluate the Goodness-of-Fit(GOF) for binned or \
-        unbinned data.",
+    description=\
+                "Evaluate the Goodness-of-Fit(GOF) for binned or \
+        unbinned data."\
+                       ,
     long_description=long_description + "\n\n" + history,
     long_description_content_type="text/markdown",
     setup_requires=["pytest-runner"],

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,7 @@ setuptools.setup(
     name="GOFevaluation",
     version="0.1.5",
     author="GOFevaluation contributors, the XENON collaboration",
-    description=\
-                "Evaluate the Goodness-of-Fit(GOF) for binned or \
-        unbinned data."\
-                       ,
+    description="Evaluate the Goodness-of-Fit(GOF) for binned or unbinned data.",
     long_description=long_description + "\n\n" + history,
     long_description_content_type="text/markdown",
     setup_requires=["pytest-runner"],

--- a/tests/test_evaluators_1d.py
+++ b/tests/test_evaluators_1d.py
@@ -15,7 +15,6 @@ from GOFevaluation.evaluators_nd import BinnedChi2GOF
 class TestKSTestGOF(unittest.TestCase):
     def test_value(self):
         """Compare result of method to manually calculated gof."""
-
         # Generate Test Data
         n_samples = 100
         # pseudo random data with fixed seed for reproducibility
@@ -51,7 +50,6 @@ class TestKSTestTwoSampleGOF(unittest.TestCase):
 
     def test_value(self):
         """Compare result of method to manually calculated gof."""
-
         # Generate Test Data (simple case of n_sample=n_reference)
         n_samples = 100
         n_reference = 300

--- a/tests/test_gof_test.py
+++ b/tests/test_gof_test.py
@@ -16,7 +16,6 @@ class TestGOFTest(unittest.TestCase):
     def test_gof(self):
         """Check if gof values of wrapper object is the same as for individual
         calculation."""
-
         # Generate data and reference (as sample and binned) to use
         # to calculate all GOFs at once
         model = sps.uniform

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -114,11 +114,11 @@ class TestPlotEqualProbable(unittest.TestCase):
             )
             error_raised = False
         except Exception:
-            print("Error correctly raised when count_density"  " mode with x or y limit specified")
+            print("Error correctly raised when count_density mode with x or y limit specified")
         else:
             if not error_raised:
                 raise RuntimeError(
-                    "Should raise error when count_density"  " mode with x or y limit specified"
+                    "Should raise error when count_density mode with x or y limit specified"
                 )
 
 

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -114,11 +114,11 @@ class TestPlotEqualProbable(unittest.TestCase):
             )
             error_raised = False
         except Exception:
-            print("Error correctly raised when count_density" " mode with x or y limit specified")
+            print("Error correctly raised when count_density"  " mode with x or y limit specified")
         else:
             if not error_raised:
                 raise RuntimeError(
-                    "Should raise error when count_density" " mode with x or y limit specified"
+                    "Should raise error when count_density"  " mode with x or y limit specified"
                 )
 
 


### PR DESCRIPTION
1. Replace `_equi` by `_weighted_equi`. When weights are not provided, the weights are assigned as 1.
2. Equal probability binning on integer sample

The extra change is done by the auto-formatter.

```
import numpy as np
import GOFevaluation as ge


reference_sample = np.repeat(
    [2, 3, 4, 5, 6, 7, 8, 9, 10],
    [127, 92, 86, 57, 40, 27, 20, 15, 12],
)

print(np.unique(reference_sample, return_counts=True))

bin_edges = ge.get_equiprobable_binning(
    reference_sample=reference_sample,
    n_partitions=5,
    integer=False,
)

print(bin_edges)

bin_edges = ge.get_equiprobable_binning(
    reference_sample=reference_sample,
    n_partitions=5,
    integer=True,
)

print(bin_edges)

h = np.histogram(reference_sample, bins=bin_edges)[0]

print(h)
```

outputs

```
(array([ 2,  3,  4,  5,  6,  7,  8,  9, 10]), array([127,  92,  86,  57,  40,  27,  20,  15,  12]))
[-inf   2.   3.   4.   6.  inf]
[-inf  2.5  3.5  4.5  6.5  inf]
[127  92  86  97  74]
```